### PR TITLE
fixes for compile errors and correct behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(PROJECT_LIBRARY_NAME ${PROJECT_NAME})
 
 # The list of all dirs containing sources to be compiled for the fclib lib
 # Any file in those dirs will be used to create libfclib
-set(${PROJECT_LIBRARY_NAME}_SRCDIRS src)
+set(${PROJECT_LIBRARY_NAME}_SRCDIRS "src;externals/SuiteSparse/CSparse")
 
 # Matching expr for files to be compiled. 
 set(EXTS *.c)

--- a/externals/SuiteSparse/CSparse/csparse.h
+++ b/externals/SuiteSparse/CSparse/csparse.h
@@ -19,7 +19,7 @@
 #define csi mwSignedIndex
 #endif
 #ifndef csi
-#define csi ptrdiff_t
+#define csi int
 #endif
 
 /* --- primary CSparse routines and data structures ------------------------- */


### PR DESCRIPTION
fclib does compile right now, see https://launchpadlibrarian.net/300151633/buildlog_ubuntu-zesty-amd64.fclib_1.0~alpha-0~201612251014~ubuntu17.04.1_BUILDING.txt.gz