### PR TITLE
Definitions and export-symbols directives for Windows; fixing non constant expressions issues in malloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,15 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE RELEASE CACHE STRING "Choose the type of build, options are: None, Debug, Release, RelWithDebInfo or MinSizeRel." FORCE)  
 endif (NOT CMAKE_BUILD_TYPE)
 
+if(MSVC)
+	option(USING_HDF5_DLLs "WIN ONLY: turn on if the shared library of HDSL is linked" ON)
+	IF (USING_HDF5_DLLs)
+		ADD_DEFINITIONS("-DH5_BUILT_AS_DYNAMIC_LIB")
+	ENDIF(USING_HDF5_DLLs)
+	ADD_DEFINITIONS("-DFCLIB_APICOMPILE=__declspec( dllexport )")
+	ADD_DEFINITIONS("-D_CRT_SECURE_NO_WARNINGS")
+endif(MSVC)
+
 # ============= Source and header files list =============
 # We scan all files with matching extension in directories 
 # containing sources.

--- a/src/fclib.c
+++ b/src/fclib.c
@@ -108,28 +108,28 @@ struct fclib_matrix* read_matrix (hid_t id)
 
   if (mat->nz >= 0) /* triplet */
   {
-    MM (mat->p = malloc (sizeof (int [mat->nz])));
-    MM (mat->i = malloc (sizeof (int [mat->nz])));
+    MM (mat->p = malloc (sizeof(int)*mat->nz));
+    MM (mat->i = malloc (sizeof(int)*mat->nz));
     IO (H5LTread_dataset_int (id, "p", mat->p));
     IO (H5LTread_dataset_int (id, "i", mat->i));
   }
   else if (mat->nz == -1) /* csc */
   {
-    MM (mat->p = malloc (sizeof (int [mat->n+1])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*mat->n+1));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     IO (H5LTread_dataset_int (id, "p", mat->p));
     IO (H5LTread_dataset_int (id, "i", mat->i));
   }
   else if (mat->nz == -2) /* csr */
   {
-    MM (mat->p = malloc (sizeof (int [mat->m+1])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*mat->m+1));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     IO (H5LTread_dataset_int (id, "p", mat->p));
     IO (H5LTread_dataset_int (id, "i", mat->i));
   }
   else ASSERT (0, "ERROR: unkown sparse matrix type => fclib_matrix->nz = %d\n", mat->nz);
 
-  MM (mat->x = malloc (sizeof (double [mat->nzmax])));
+  MM (mat->x = malloc (sizeof(double)*mat->nzmax));
   IO (H5LTread_dataset_double (id, "x", mat->x));
 
   if (H5LTfind_dataset (id, "conditioning"))
@@ -142,7 +142,7 @@ struct fclib_matrix* read_matrix (hid_t id)
     if (H5LTfind_dataset (id, "comment"))
     {
       IO (H5LTget_dataset_info  (id, "comment", &dim, &class_id, &size));
-      MM (mat->info->comment = malloc (sizeof (char [size])));
+      MM (mat->info->comment = malloc (sizeof(char)*size));
       IO (H5LTread_dataset_string (id, "comment", mat->info->comment));
     }
     else mat->info->comment = NULL;
@@ -185,18 +185,18 @@ static void write_global_vectors (hid_t id, struct fclib_global *problem)
 /** read global vectors */
 static void read_global_vectors (hid_t id, struct fclib_global *problem)
 {
-  MM (problem->f = malloc (sizeof (double [problem->M->m])));
+  MM (problem->f = malloc (sizeof(double)*problem->M->m));
   IO (H5LTread_dataset_double (id, "f", problem->f));
 
   ASSERT (problem->H->n % problem->spacedim == 0, "ERROR: number of H columns is not divisble by the spatial dimension");
-  MM (problem->w = malloc (sizeof (double [problem->H->n])));
-  MM (problem->mu = malloc (sizeof (double [problem->H->n / problem->spacedim])));
+  MM (problem->w = malloc (sizeof(double)*problem->H->n));
+  MM (problem->mu = malloc (sizeof(double)*(problem->H->n / problem->spacedim)));
   IO (H5LTread_dataset_double (id, "w", problem->w));
   IO (H5LTread_dataset_double (id, "mu", problem->mu));
 
   if (problem->G)
   {
-    MM (problem->b = malloc (sizeof (double [problem->G->n])));
+    MM (problem->b = malloc (sizeof(double)*problem->G->n));
     IO (H5LTread_dataset_double (id, "b", problem->b));
   }
 }
@@ -225,16 +225,16 @@ static void write_local_vectors (hid_t id, struct fclib_local *problem)
 /** read local vectors */
 static void read_local_vectors (hid_t id, struct fclib_local *problem)
 {
-  MM (problem->q = malloc (sizeof (double [problem->W->m])));
+  MM (problem->q = malloc (sizeof(double)*problem->W->m));
   IO (H5LTread_dataset_double (id, "q", problem->q));
 
   ASSERT (problem->W->m % problem->spacedim == 0, "ERROR: number of W rows is not divisble by the spatial dimension");
-  MM (problem->mu = malloc (sizeof (double [problem->W->m / problem->spacedim])));
+  MM (problem->mu = malloc (sizeof(double)*(problem->W->m / problem->spacedim)));
   IO (H5LTread_dataset_double (id, "mu", problem->mu));
 
   if (problem->R)
   {
-    MM (problem->s = malloc (sizeof (double [problem->R->m])));
+    MM (problem->s = malloc (sizeof(double)*problem->R->m));
     IO (H5LTread_dataset_double (id, "s", problem->s));
   }
 }
@@ -260,7 +260,7 @@ static struct fclib_info* read_problem_info (hid_t id)
   if (H5LTfind_dataset (id, "title"))
   {
     IO (H5LTget_dataset_info  (id, "title", &dim, &class_id, &size));
-    MM (info->title = malloc (sizeof (char [size])));
+    MM (info->title = malloc (sizeof(char)*size));
     IO (H5LTread_dataset_string (id, "title", info->title));
   }
   else info->title = NULL;
@@ -268,7 +268,7 @@ static struct fclib_info* read_problem_info (hid_t id)
   if (H5LTfind_dataset (id, "description"))
   {
     IO (H5LTget_dataset_info  (id, "description", &dim, &class_id, &size));
-    MM (info->description = malloc (sizeof (char [size])));
+    MM (info->description = malloc (sizeof(char)*size));
     IO (H5LTread_dataset_string (id, "description", info->description));
   }
   else info->description = NULL;
@@ -276,7 +276,7 @@ static struct fclib_info* read_problem_info (hid_t id)
   if (H5LTfind_dataset (id, "math_info"))
   {
     IO (H5LTget_dataset_info  (id, "math_info", &dim, &class_id, &size));
-    MM (info->math_info = malloc (sizeof (char [size])));
+    MM (info->math_info = malloc (sizeof(char)*size));
     IO (H5LTread_dataset_string (id, "math_info", info->math_info));
   }
   else info->math_info = NULL;
@@ -300,22 +300,22 @@ static void read_solution (hid_t id, hsize_t nv, hsize_t nr, hsize_t nl, struct 
 {
   if (nv)
   {
-    MM (solution->v = malloc (sizeof (double [nv])));
+    MM (solution->v = malloc (sizeof(double)*nv));
     IO (H5LTread_dataset_double (id, "v", solution->v));
   }
   else solution->v = NULL;
 
   if (nl)
   {
-    MM (solution->l = malloc (sizeof (double [nl])));
+    MM (solution->l = malloc (sizeof(double)*nl));
     IO (H5LTread_dataset_double (id, "l", solution->l));
   }
   else solution->l = NULL;
 
   ASSERT (nr, "ERROR: contact constraints must be present");
-  MM (solution->u = malloc (sizeof (double [nr])));
+  MM (solution->u = malloc (sizeof(double)*nr));
   IO (H5LTread_dataset_double (id, "u", solution->u));
-  MM (solution->r = malloc (sizeof (double [nr])));
+  MM (solution->r = malloc (sizeof(double)*nr));
   IO (H5LTread_dataset_double (id, "r", solution->r));
 }
 

--- a/src/fclib.h
+++ b/src/fclib.h
@@ -83,11 +83,16 @@
 #ifndef _fclib_h_
 #define _fclib_h_
 
+#ifndef FCLIB_APICOMPILE
+#define FCLIB_APICOMPILE
+#endif
+
+
 /**\struct  fclib_info fclib.h
  * This structure allows the user to enter a  problem information  as a title, a short description and known mathematical properties of the problem
  */
 
-struct fclib_info
+struct FCLIB_APICOMPILE fclib_info
 {
   /** title of the problem*/
   char *title;
@@ -100,7 +105,7 @@ struct fclib_info
 /**\struct  fclib_matrix_info fclib.h
  * This structure allows the user to enter a description for a given matrix (comment, conditionning, determinant, rank.) if they are known.
  */
-struct fclib_matrix_info  /* matrix information */
+struct FCLIB_APICOMPILE fclib_matrix_info  /* matrix information */
 {
   /** comment on the matrix properties*/
   char *comment;
@@ -115,7 +120,7 @@ struct fclib_matrix_info  /* matrix information */
 /**\struct  fclib_matrix fclib.h
  * matrix in compressed row/column or triplet form
  */
-struct fclib_matrix   /*  */
+struct FCLIB_APICOMPILE fclib_matrix   /*  */
 {
   /** maximum number of entries */
   int nzmax ;
@@ -170,7 +175,7 @@ struct fclib_matrix   /*  */
  *\f}
  * and the set \f$C^{\alpha,\star}_{\mu^\alpha}\f$ is its dual.
  */
-struct fclib_global
+struct FCLIB_APICOMPILE fclib_global
 {
   /** the matrix M (see mathematical description below)*/
   struct fclib_matrix *M;
@@ -224,7 +229,7 @@ struct fclib_global
  * \f}
  * and the set \f$C^{\alpha,\star}_{\mu^\alpha}\f$ is its dual.
  */
-struct fclib_local
+struct FCLIB_APICOMPILE fclib_local
 {
   /** the matrix W (see mathematical description below)*/
   struct fclib_matrix *W;
@@ -250,7 +255,7 @@ struct fclib_local
  * This structure allows to store a solution vector of a guess vector for the
  * various frictional contact problems.
  */
-struct fclib_solution /* solution data */
+struct FCLIB_APICOMPILE fclib_solution /* solution data */
 {
   /** global velocity (or position/displacement for quasi-static problems) solution vector */
   double *v;
@@ -265,58 +270,59 @@ struct fclib_solution /* solution data */
 /** \enum  fclib_merit
  * MERIT_1 is a implementation of the merit function based on the natural map for a SOCCP
  */
-enum fclib_merit {MERIT_1, MERIT_2} ; /* merit functions */
+enum FCLIB_APICOMPILE fclib_merit {MERIT_1, MERIT_2} ; /* merit functions */
 
 /** write global problem;
  * return 1 on success, 0 on failure */
-int fclib_write_global (struct fclib_global *problem, const char *path);
+int FCLIB_APICOMPILE fclib_write_global (struct fclib_global *problem, const char *path);
 
 /** write local problem;
  * return 1 on success, 0 on failure */
-int fclib_write_local (struct fclib_local *problem, const char *path);
+int FCLIB_APICOMPILE fclib_write_local (struct fclib_local *problem, const char *path);
 
 /** write solution;
  * return 1 on success, 0 on failure */
-int fclib_write_solution (struct fclib_solution *solution, const char *path);
+int FCLIB_APICOMPILE fclib_write_solution (struct fclib_solution *solution, const char *path);
 
 /** write initial guesses;
  * return 1 on success, 0 on failure */
-int fclib_write_guesses (int number_of_guesses,  struct fclib_solution *guesses, const char *path);
+int FCLIB_APICOMPILE fclib_write_guesses (int number_of_guesses,  struct fclib_solution *guesses, const char *path);
 
 /** read global problem;
  * return problem on success; NULL on failure */
-struct fclib_global* fclib_read_global (const char *path);
+FCLIB_APICOMPILE struct fclib_global* fclib_read_global (const char *path);
 
 /** read local problem;
  * return problem on success; NULL on failure */
-struct fclib_local* fclib_read_local (const char *path);
+FCLIB_APICOMPILE struct fclib_local* fclib_read_local (const char *path);
 
 /** read solution;
  * return solution on success; NULL on failure */
-struct fclib_solution* fclib_read_solution (const char *path);
+FCLIB_APICOMPILE struct fclib_solution* fclib_read_solution (const char *path);
 
 /** read initial guesses;
  * return vector of guesses on success; NULL on failure;
  * output numebr of guesses in the variable pointed by 'number_of_guesses' */
-struct fclib_solution* fclib_read_guesses (const char *path, int *number_of_guesses);
+FCLIB_APICOMPILE struct fclib_solution* fclib_read_guesses (const char *path, int *number_of_guesses);
 
 /** calculate merit function for a global problem */
-double fclib_merit_global (struct fclib_global *problem, enum fclib_merit merit, struct fclib_solution *solution);
+double FCLIB_APICOMPILE fclib_merit_global (struct fclib_global *problem, enum fclib_merit merit, struct fclib_solution *solution);
 
 /** calculate merit function for a local problem */
-double fclib_merit_local (struct fclib_local *problem, enum fclib_merit merit, struct fclib_solution *solution);
+double FCLIB_APICOMPILE fclib_merit_local (struct fclib_local *problem, enum fclib_merit merit, struct fclib_solution *solution);
 
 /** delete global problem */
-void fclib_delete_global (struct fclib_global *problem);
+void FCLIB_APICOMPILE fclib_delete_global (struct fclib_global *problem);
 
 /** delete local problem */
-void fclib_delete_local (struct fclib_local *problem);
+void FCLIB_APICOMPILE fclib_delete_local (struct fclib_local *problem);
 
 /** delete solutions or guesses */
-void fclib_delete_solutions (struct fclib_solution *data, int count);
+void FCLIB_APICOMPILE fclib_delete_solutions (struct fclib_solution *data, int count);
 
 /** create and set attributes of tyoe int in info */
-int fclib_create_int_attributes_in_info(const char *path, const char * attr_name,
+int FCLIB_APICOMPILE fclib_create_int_attributes_in_info(const char *path, const char * attr_name,
                                         int attr_value);
+
 
 #endif /* _fclib_h_ */

--- a/src/tests/fctst.c
+++ b/src/tests/fctst.c
@@ -58,8 +58,8 @@ static struct fclib_matrix* random_matrix (int m, int n)
   if (rand () % 2) /* triplet */
   {
     mat->nz = mat->nzmax;
-    MM (mat->p = malloc (sizeof (int [mat->nzmax])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*mat->nzmax));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     for (j = 0; j < mat->nzmax; j ++)
     {
       mat->p [j] = rand () % mat->m;
@@ -70,14 +70,14 @@ static struct fclib_matrix* random_matrix (int m, int n)
   {
     mat->nz = (rand () % 2 ? -1 : -2); /* csc / csr */
     int k = (mat->nz == -1 ? mat->n : mat->m);
-    MM (mat->p = malloc (sizeof (int [k+1])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*k+1));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     int l = mat->nzmax / k;
     for (mat->p [0] = j = 0; j < k; j ++) mat->p [j+1] = mat->p [j] + l;
     for (j = 0; j < mat->nzmax; j ++) mat->i [j] = rand () % k;
   }
 
-  MM (mat->x = malloc (sizeof (double [mat->nzmax])));
+  MM (mat->x = malloc (sizeof(double)*mat->nzmax));
   for (j = 0; j < mat->nzmax; j ++) mat->x [j] = (double) rand ()  / (double) RAND_MAX;
 
   if (rand ()) mat->info = matrix_info (mat, "A random matrix");
@@ -91,7 +91,7 @@ static double* random_vector (int n)
 {
   double *v;
 
-  MM (v = malloc (sizeof (double [n])));
+  MM (v = malloc (sizeof(double)*n));
   for (n --; n >= 0; n --) v [n] = (double) rand () / (double) RAND_MAX;
 
   return v;
@@ -400,7 +400,7 @@ int main (int argc, char **argv)
 {
   int i;
 
-  srand (time (NULL));
+  srand ((unsigned int)time (NULL));
 
   if (rand () % 2)
   {

--- a/src/tests/fctst_merit.c
+++ b/src/tests/fctst_merit.c
@@ -60,8 +60,8 @@ static struct fclib_matrix* random_matrix (int m, int n)
   if (rand () % 2) /* triplet */
   {
     mat->nz = mat->nzmax;
-    MM (mat->p = malloc (sizeof (int [mat->nzmax])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*mat->nzmax));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     for (j = 0; j < mat->nzmax; j ++)
     {
       mat->p [j] = rand () % mat->m;
@@ -72,14 +72,14 @@ static struct fclib_matrix* random_matrix (int m, int n)
   {
     mat->nz = (rand () % 2 ? -1 : -2); /* csc / csr */
     int k = (mat->nz == -1 ? mat->n : mat->m);
-    MM (mat->p = malloc (sizeof (int [k+1])));
-    MM (mat->i = malloc (sizeof (int [mat->nzmax])));
+    MM (mat->p = malloc (sizeof(int)*k+1));
+    MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     int l = mat->nzmax / k;
     for (mat->p [0] = j = 0; j < k; j ++) mat->p [j+1] = mat->p [j] + l;
     for (j = 0; j < mat->nzmax; j ++) mat->i [j] = rand () % k;
   }
 
-  MM (mat->x = malloc (sizeof (double [mat->nzmax])));
+  MM (mat->x = malloc (sizeof(double)*mat->nzmax));
   for (j = 0; j < mat->nzmax; j ++) mat->x [j] = (double) rand ()  / (double) RAND_MAX;
 
   if (rand ()) mat->info = matrix_info (mat, "A random matrix");
@@ -93,7 +93,7 @@ static double* random_vector (int n)
 {
   double *v;
 
-  MM (v = malloc (sizeof (double [n])));
+  MM (v = malloc (sizeof(double)*n));
   for (n --; n >= 0; n --) v [n] = (double) rand () / (double) RAND_MAX;
 
   return v;


### PR DESCRIPTION
- in Windows, no symbols are exported by default into shared libraries. Added __declspec(dllexport) directives to class/struct/functions declarations in order to export them;
- silenced warnings for deprecated functions.
- malloc is called with sizeof(<array_type>[<array_dimension>]), but this asks for <array_dimension> to be a const expression which is not.
It suffices to change it in sizeof(<array_type>)*<array_dimension>.

This commit shouldn't break compatibility with Linux.