### PR TITLE
Fix build and arithmetic mistake

### DIFF
--- a/src/fclib.h
+++ b/src/fclib.h
@@ -365,7 +365,6 @@ FCLIB_STATIC int fclib_create_int_attributes_in_info(const char *path,
 #include <stdio.h>
 #include <hdf5.h>
 #include <hdf5_hl.h>
-#include "fcint.h"
 #include <csparse.h>
 
 /* useful macros */

--- a/src/fclib.h
+++ b/src/fclib.h
@@ -459,14 +459,14 @@ FCLIB_STATIC struct fclib_matrix* read_matrix (hid_t id)
   }
   else if (mat->nz == -1) /* csc */
   {
-    MM (mat->p = malloc (sizeof(int)*mat->n+1));
+    MM (mat->p = malloc (sizeof(int)*(mat->n+1)));
     MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     IO (H5LTread_dataset_int (id, "p", mat->p));
     IO (H5LTread_dataset_int (id, "i", mat->i));
   }
   else if (mat->nz == -2) /* csr */
   {
-    MM (mat->p = malloc (sizeof(int)*mat->m+1));
+    MM (mat->p = malloc (sizeof(int)*(mat->m+1)));
     MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     IO (H5LTread_dataset_int (id, "p", mat->p));
     IO (H5LTread_dataset_int (id, "i", mat->i));

--- a/src/tests/fctst.c
+++ b/src/tests/fctst.c
@@ -26,7 +26,16 @@
 #include <stdio.h>
 #include <time.h>
 #include "fclib.h"
-#include "fcint.h"
+
+/* useful macros */
+#define ASSERT(Test, ...)\
+  do {\
+  if (! (Test)) { fprintf (stderr, "%s: %d => ", __FILE__, __LINE__);\
+    fprintf (stderr, __VA_ARGS__);\
+    fprintf (stderr, "\n"); exit (1); } } while (0)
+
+#define IO(Call) ASSERT ((Call) >= 0, "ERROR: HDF5 call failed")
+#define MM(Call) ASSERT ((Call), "ERROR: out of memory")
 
 /* allocate matrix info */
 static struct fclib_matrix_info* matrix_info (struct fclib_matrix *mat, char *comment)

--- a/src/tests/fctst.c
+++ b/src/tests/fctst.c
@@ -79,7 +79,7 @@ static struct fclib_matrix* random_matrix (int m, int n)
   {
     mat->nz = (rand () % 2 ? -1 : -2); /* csc / csr */
     int k = (mat->nz == -1 ? mat->n : mat->m);
-    MM (mat->p = malloc (sizeof(int)*k+1));
+    MM (mat->p = malloc (sizeof(int)*(k+1)));
     MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     int l = mat->nzmax / k;
     for (mat->p [0] = j = 0; j < k; j ++) mat->p [j+1] = mat->p [j] + l;

--- a/src/tests/fctst_merit.c
+++ b/src/tests/fctst_merit.c
@@ -28,7 +28,16 @@
 #include <stdio.h>
 #include <time.h>
 #include "fclib.h"
-#include "fcint.h"
+
+/* useful macros */
+#define ASSERT(Test, ...)\
+  do {\
+  if (! (Test)) { fprintf (stderr, "%s: %d => ", __FILE__, __LINE__);\
+    fprintf (stderr, __VA_ARGS__);\
+    fprintf (stderr, "\n"); exit (1); } } while (0)
+
+#define IO(Call) ASSERT ((Call) >= 0, "ERROR: HDF5 call failed")
+#define MM(Call) ASSERT ((Call), "ERROR: out of memory")
 
 /* allocate matrix info */
 static struct fclib_matrix_info* matrix_info (struct fclib_matrix *mat, char *comment)

--- a/src/tests/fctst_merit.c
+++ b/src/tests/fctst_merit.c
@@ -81,7 +81,7 @@ static struct fclib_matrix* random_matrix (int m, int n)
   {
     mat->nz = (rand () % 2 ? -1 : -2); /* csc / csr */
     int k = (mat->nz == -1 ? mat->n : mat->m);
-    MM (mat->p = malloc (sizeof(int)*k+1));
+    MM (mat->p = malloc (sizeof(int)*(k+1)));
     MM (mat->i = malloc (sizeof(int)*mat->nzmax));
     int l = mat->nzmax / k;
     for (mat->p [0] = j = 0; j < k; j ++) mat->p [j+1] = mat->p [j] + l;


### PR DESCRIPTION
- build was broken with the removal of fcint.h
- the was a missing parenthesis in the allocation class, resulting in an smaller allocated area and leading to memory issues.