### PR TITLE
improve the case when we compile fclib into a library

### DIFF
--- a/CMake/InstallPackage.cmake
+++ b/CMake/InstallPackage.cmake
@@ -42,18 +42,19 @@ macro(install_package _PACK _LIB_NAME _HEADERSLIST)
   
   # Install the export set for use with the install-tree
   install(EXPORT ${_PACK}LibraryDepends DESTINATION
-    "${INSTALL_DATA_DIR}/CMake" COMPONENT dev)
+    "${CMAKE_INSTALL_LIBDIR}/cmake/${_PACK}" COMPONENT dev)
   
-  set(${_PACK}_INCLUDE_DIRS "${INSTALL_INCLUDE_DIR}")
-  set(${_PACK}_LIB_DIR "${INSTALL_LIB_DIR}")
-  set(${_PACK}_CMAKE_DIR "${INSTALL_DATA_DIR}/CMake")
-  configure_file(${_PACK}Config.cmake.in
-    "${PROJECT_BINARY_DIR}/InstallFiles/${_PACK}Config.cmake")
-  configure_file(${_PACK}ConfigVersion.cmake.in
-    "${PROJECT_BINARY_DIR}/InstallFiles/${_PACK}ConfigVersion.cmake" @ONLY)
-  install(FILES
-    "${PROJECT_BINARY_DIR}/InstallFiles/${_PACK}Config.cmake"
-    "${PROJECT_BINARY_DIR}/InstallFiles/${_PACK}ConfigVersion.cmake"
-    DESTINATION "${${_PACK}_CMAKE_DIR}" COMPONENT dev)
-  
+   include(CMakePackageConfigHelpers)
+  configure_package_config_file(${_PACK}Config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${_PACK}Config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_PACK}
+    PATH_VARS INCLUDE_INSTALL_DIR)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/${_PACK}ConfigVersion.cmake
+    VERSION ${${_PACK}_version}
+    COMPATIBILITY SameMajorVersion )
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${_PACK}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${_PACK}ConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${_PACK} )
+   
 endmacro()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,10 @@ IF(APPLE)
 ENDIF(APPLE)
 
 # User defined options
-option(FCLIB_WITH_MERIT_FUNCTIONS "enable merit functions. Default = ON" OFF)
+option(FCLIB_WITH_MERIT_FUNCTIONS "enable merit functions. Default = ON" ON)
 option(FCLIB_HEADER_ONLY "static interface. Default = ON" ON)
 option(VERBOSE_MODE "enable verbose mode for cmake exec. Default = ON" ON)
-option(USE_MPI "compile and link fclib with mpi when this mode is enable. Default = ON" OFF)
+option(USE_MPI "compile and link fclib with mpi when this mode is enable.  Default = OFF" OFF)
 option(BUILD_SHARED_LIBS "Enable dynamic library build, default = ON" ON)
 option(WITH_TESTS "Enable testing. Default = ON" ON)
 option(FORCE_SKIP_RPATH "Do not build shared libraries with rpath. Useful only for packaging. Default = OFF" OFF)
@@ -102,13 +102,13 @@ include_directories(${HDF5_INCLUDE_DIRS})
 set(LIBS ${LIBS} ${HDF5_LIBRARIES} ${HDF5_HL_LIBRARIES})
 display(HDF5_INCLUDE_DIRS)
 
-if(FCLIB_WITH_MERIT_FUNCTIONS)
-  add_definitions("-DFCLIB_WITH_MERIT_FUNCTIONS")
+if(NOT FCLIB_HEADER_ONLY)
+  set(FCLIB_NOT_HEADER_ONLY TRUE)
 endif()
 
-if(NOT FCLIB_HEADER_ONLY)
-  add_definitions("-DFCLIB_NOT_HEADER_ONLY")
-endif()
+CONFIGURE_FILE( ${CMAKE_SOURCE_DIR}/fclib.h.cmake ${CMAKE_BINARY_DIR}/fclib.h)
+include_directories(${CMAKE_BINARY_DIR})
+install(FILES ${CMAKE_BINARY_DIR}/fclib.h DESTINATION include)
 
 # --- MPI ---
 if(USE_MPI)
@@ -248,13 +248,15 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # The library, the headers and mod files, the cmake generated files
 # will be install in CMAKE_INSTALL_PREFIX/lib include and share
 display(${PROJECT_LIBRARY_NAME}_HDRS)
-set(${PROJECT_LIBRARY_NAME}_INSTALL_HDRS "${CMAKE_SOURCE_DIR}/src/fclib.h;")
+set(${PROJECT_LIBRARY_NAME}_INSTALL_HDRS "${CMAKE_SOURCE_DIR}/src/fclib_priv.h;")
+
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include)
 
 if(FCLIB_WITH_MERIT_FUNCTIONS OR NOT FCLIB_HEADER_ONLY)
   include(InstallPackage)
-  install_package(${PACKAGE_NAME} ${PROJECT_LIBRARY_NAME} ${PROJECT_LIBRARY_NAME}_INSTALL_HDRS)
+ install_package(${PACKAGE_NAME} ${PROJECT_LIBRARY_NAME} ${PROJECT_LIBRARY_NAME}_INSTALL_HDRS)
 else()
-  install(FILES ${${PROJECT_LIBRARY_NAME}_INSTALL_HDRS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+  install(FILES ${${PROJECT_LIBRARY_NAME}_INSTALL_HDRS} DESTINATION ${INCLUDE_INSTALL_DIR})
 endif()
 # ============= Summary =============
 if(VERBOSE_MODE)

--- a/FCLibConfig.cmake.in
+++ b/FCLibConfig.cmake.in
@@ -9,23 +9,20 @@
 # @PACKAGE_NAME@_INCLUDE_DIRS - include directories for ppmcore
 # @PACKAGE_NAME@_EXTRA_INCLUDE_DIRS - path to extra headers needed for @PACKAGE_NAME@ (metis.h ...)
 # @PACKAGE_NAME@_LIBRARY_DIRS - path to @PACKAGE_NAME@ library(ies)
-# @PACKAGE_NAME@_LIBRARIES  - libraries to link against to use ppmcore
+# @PACKAGE_NAME@_LIBRARIES  - libraries to link against to use @PACKAGE_NAME@
 # @PACKAGE_NAME@_USE_XXX - value of option "USE_XXX" (for example USE_MPI, USE_Metis ... = ON or OFF)
 
-# Tell the user where to find ppmcore headers
-# Tell the user project where to find our headers and libraries
-set(@PACKAGE_NAME@_INCLUDE_DIRS "${${PACKAGE_NAME}_INCLUDE_DIRS}")
-set(@PACKAGE_NAME@_EXTRA_INCLUDE_DIRS "${${PACKAGE_NAME}_EXTRA_INCLUDE_DIRS}")
-set(@PACKAGE_NAME@_LIBRARY_DIRS "${${PACKAGE_NAME}_LIB_DIR}")
-set(@PACKAGE_NAME@_MODULE_DIR "${${PACKAGE_NAME}_INCLUDE_DIRS}/Modules")
+@PACKAGE_INIT@
+
+set_and_check(@PACKAGE_NAME@_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+check_required_components(@PACKAGE_NAME@)
 
 # Our library dependencies (contains definitions for IMPORTED targets)
-include("${${PACKAGE_NAME}_CMAKE_DIR}/@PACKAGE_NAME@LibraryDepends.cmake")
- 
+include("${CMAKE_CURRENT_LIST_DIR}/@PACKAGE_NAME@LibraryDepends.cmake")
+
 # These are IMPORTED targets created by FooBarLibraryDepends.cmake
 set(@PACKAGE_NAME@_LIBRARIES @PROJECT_LIBRARY_NAME@)
 
 # Set all @PACKAGE_NAME@ options
 set(@PACKAGE_NAME@_USE_MPI @USE_MPI@)
-
-

--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,4 @@
-To compile and install fclib : 
+To compile and install fclib:
 
 cd SOME_BUILD_DIR
 cmake path_to_fclib -DCMAKE_INSTALL_PREFIX=where_to_install_fclib

--- a/README.md
+++ b/README.md
@@ -34,3 +34,6 @@ How to download the collection of problems ?
 
 * The problems are stored on a github repo [fclib-library](https://github.com/FrictionalContactLibrary/fclib-library) with the help of git-lfs 
 * The [latest tagged releases](https://github.com/FrictionalContactLibrary/fclib-library/releases) of the library of problems
+
+The library comes in two versions: either a header only, available with the inclusion of fclib.h in the sources. It is also possible to compile
+FCLib into a library with cmake

--- a/fclib.h
+++ b/fclib.h
@@ -1,0 +1,26 @@
+/* FCLIB Copyright (C) 2011--2016 FClib project
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: fclib-project@lists.gforge.inria.fr
+*/
+
+/** This file is for the header-only version of FCLib*/
+
+#ifndef _fclib_h_
+#define _fclib_h_
+
+#include <fclib_priv.h>
+
+#endif

--- a/fclib.h.cmake
+++ b/fclib.h.cmake
@@ -1,0 +1,33 @@
+/* FCLIB Copyright (C) 2011--2016 FClib project
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: fclib-project@lists.gforge.inria.fr
+*/
+
+
+/*!\file fclib.h
+ * ----------------------------------------------
+ * frictional contact library input/output
+ */
+
+#ifndef _fclib_h_
+#define _fclib_h_
+
+#cmakedefine FCLIB_WITH_MERIT_FUNCTIONS
+#cmakedefine FCLIB_NOT_HEADER_ONLY
+
+#include <fclib_priv.h>
+
+#endif

--- a/src/fclib_priv.h
+++ b/src/fclib_priv.h
@@ -17,7 +17,7 @@
 */
 
 
-/*!\file fclib.h
+/*!\file fclib_priv.h
  * -----------------------------------------
  * frictional contact library interface
  * -----------------------------------------
@@ -85,7 +85,11 @@
  */
 
 #ifndef _fclib_h_
-#define _fclib_h_
+#error "do not include fclib_priv.h, but rather fclib.h"
+#endif
+
+#ifndef _fclib_priv_h_
+#define _fclib_priv_h_
 
 #ifndef FCLIB_APICOMPILE
 #define FCLIB_APICOMPILE
@@ -103,7 +107,7 @@
 #define H5Gcreate_vers 2
 #define H5Gopen_vers 2
 
-/**\struct  fclib_info fclib.h
+/**\struct  fclib_info fclib_priv.h
  * This structure allows the user to enter a  problem information  as a title, a short description and known mathematical properties of the problem
  */
 
@@ -117,7 +121,7 @@ struct FCLIB_APICOMPILE fclib_info
   char *math_info;
 };
 
-/**\struct fclib_matrix_info fclib.h
+/**\struct fclib_matrix_info fclib_priv.h
  * This structure allows the user to enter a description for a given
  * matrix (comment, conditionning, determinant, rank.) if they are
  * known.
@@ -134,7 +138,7 @@ struct FCLIB_APICOMPILE fclib_matrix_info  /* matrix information */
   int rank;
 };
 
-/**\struct  fclib_matrix fclib.h
+/**\struct  fclib_matrix fclib_priv.h
  * matrix in compressed row/column or triplet form
  */
 struct FCLIB_APICOMPILE fclib_matrix   /*  */
@@ -157,7 +161,7 @@ struct FCLIB_APICOMPILE fclib_matrix   /*  */
   struct fclib_matrix_info *info;
 };
 
-/**\struct fclib_global fclib.h
+/**\struct fclib_global fclib_priv.h
  * The global frictional contact problem defined by
  *
  * Given
@@ -213,7 +217,7 @@ struct FCLIB_APICOMPILE fclib_global
   /** info on the problem */
   struct fclib_info *info;
 };
-/**\struct fclib_local fclib.h
+/**\struct fclib_local fclib_priv.h
  * The local frictional contact problem defined by
  *
  * given
@@ -266,7 +270,7 @@ struct FCLIB_APICOMPILE fclib_local
   struct fclib_info *info;
 };
 
-/** \struct fclib_solution fclib.h
+/** \struct fclib_solution fclib_priv.h
  *  A solution or a guess for the frictional contact problem.
  *
  * This structure allows to store a solution vector of a guess vector for the


### PR DESCRIPTION
Several things were broken when the library was compiled. This PR ensures that the header fclib.h, installed on the system is consistent and self-sufficient w.r.t the options chosen at compile-time.