### PR TITLE
Wrong argument to cs_transpose leads to segfault

### DIFF
--- a/src/fclib.h
+++ b/src/fclib.h
@@ -1591,7 +1591,7 @@ FCLIB_STATIC double fclib_merit_local (struct fclib_local *problem, enum fclib_m
     /* compute V^T {r} + R \lambda + s */
     if (n_e >0)
     {
-      cs * VT = cs_transpose((cs *)V, 0) ;
+      cs * VT = cs_transpose((cs *)V, 1) ;
       tmp = (double *)malloc(n_e*sizeof(double));
       for (i =0; i <n_e; i++) tmp[i] = s[i] ;
       cs_gaxpy(VT, r, tmp);


### PR DESCRIPTION
Quite some time ago I fixed a bug in the Debian package of a segfault randomly happening during testing.  At the time I determined that the argument to `cs_transpose` was incorrect and caused a segfault randomly during testing.

The segfault can be reproduced (without this patch) by setting the random seed in fctst:

```
diff --git a/src/tests/fctst.c b/src/tests/fctst.c
index 13f34be..0771a57 100644
--- a/src/tests/fctst.c
+++ b/src/tests/fctst.c
@@ -410,6 +410,7 @@ int main (int argc, char **argv)
   int i;
 
   srand ((unsigned int)time (NULL));
+  srand(1591903824);
 
   if (rand () % 2)
   {
```

Incidentally it's probably not a great idea to have a random number involved in a test.

Anyway, this patch fixes this problem, but I would prefer someone verify the correctness of the fix, as it's rather obscure.

I am now looking at this because I want to update the Siconos package to 4.4.0, but for this we need to have a new fclib release that includes the new functions related to rolling problems.